### PR TITLE
fix: update deprecated Claude model + retry workflow fault isolation

### DIFF
--- a/.github/workflows/retry-uploads.yml
+++ b/.github/workflows/retry-uploads.yml
@@ -26,6 +26,8 @@ jobs:
         run: pip install -r pipeline/requirements.txt
 
       - name: Swap old videos (delete + re-upload with new text)
+        continue-on-error: true
+        id: swap
         env:
           YOUTUBE_CLIENT_ID: ${{ secrets.YOUTUBE_CLIENT_ID }}
           YOUTUBE_CLIENT_SECRET: ${{ secrets.YOUTUBE_CLIENT_SECRET }}
@@ -33,6 +35,8 @@ jobs:
         run: python pipeline/youtube_upload.py --swap-old
 
       - name: Upload pending new videos
+        continue-on-error: true
+        id: upload
         env:
           YOUTUBE_CLIENT_ID: ${{ secrets.YOUTUBE_CLIENT_ID }}
           YOUTUBE_CLIENT_SECRET: ${{ secrets.YOUTUBE_CLIENT_SECRET }}
@@ -40,6 +44,8 @@ jobs:
         run: python pipeline/youtube_upload.py --all
 
       - name: Pull YouTube view counts
+        continue-on-error: true
+        id: views
         env:
           YOUTUBE_CLIENT_ID: ${{ secrets.YOUTUBE_CLIENT_ID }}
           YOUTUBE_CLIENT_SECRET: ${{ secrets.YOUTUBE_CLIENT_SECRET }}
@@ -58,23 +64,27 @@ jobs:
             git push
           fi
 
-      - name: Alert on failure
-        if: failure()
+      - name: Report failures
+        if: always()
         env:
           RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
           NOTIFY_EMAIL: ${{ secrets.NOTIFY_EMAIL }}
         run: |
-          python -c "
-          import httpx, os
-          api_key = os.environ.get('RESEND_API_KEY', '')
-          notify = os.environ.get('NOTIFY_EMAIL', '')
-          if api_key and notify:
-              httpx.post('https://api.resend.com/emails',
-                  headers={'Authorization': f'Bearer {api_key}'},
-                  json={
-                      'from': 'Lotus Lane Bot <notifications@rxjapps.in>',
-                      'to': [notify],
-                      'subject': 'Lotus Lane: YouTube upload retry FAILED',
-                      'html': '<p>YouTube upload retry failed. <a href=\"https://github.com/zombielabsv2/lotus-lane/actions\">Check Actions</a></p>'
-                  })
-          "
+          FAILURES=""
+          if [ "${{ steps.swap.outcome }}" == "failure" ]; then FAILURES="$FAILURES- Swap old videos FAILED\n"; fi
+          if [ "${{ steps.upload.outcome }}" == "failure" ]; then FAILURES="$FAILURES- Upload pending videos FAILED\n"; fi
+          if [ "${{ steps.views.outcome }}" == "failure" ]; then FAILURES="$FAILURES- Pull view counts FAILED\n"; fi
+
+          if [ -n "$FAILURES" ]; then
+            echo "## YouTube Retry Failures" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo -e "$FAILURES" >> $GITHUB_STEP_SUMMARY
+
+            if [ -n "$RESEND_API_KEY" ] && [ -n "$NOTIFY_EMAIL" ]; then
+              export FAIL_TEXT=$(echo -e "$FAILURES")
+              export RUN_URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+              python pipeline/send_failure_alert.py
+            fi
+          else
+            echo "All YouTube retry steps succeeded." >> $GITHUB_STEP_SUMMARY
+          fi

--- a/pipeline/generate_strip.py
+++ b/pipeline/generate_strip.py
@@ -185,7 +185,7 @@ Return ONLY the JSON, no other text."""
             "content-type": "application/json",
         },
         json={
-            "model": "claude-sonnet-4-20250514",
+            "model": "claude-sonnet-4-6",
             "max_tokens": 2000,
             "messages": [{"role": "user", "content": prompt}],
         },


### PR DESCRIPTION
## Summary
- **generate_strip.py**: Update Claude model from `claude-sonnet-4-20250514` (deprecated, ~11 months old) to `claude-sonnet-4-6` (current). This was causing the strip generator to crash after ~3m19s (setup time + immediate API rejection).
- **retry-uploads.yml**: Add `continue-on-error: true` + step IDs to `--swap-old`, `--all`, and `--views` steps so failures in one don't block the others or the `git push`. Replace inline Python alert with structured failure reporting via `send_failure_alert.py`.

## Test plan
- [x] All 102 tests pass (`pytest tests/ -v`)
- [x] YAML validated for both workflow files
- [ ] Trigger generate-strip workflow manually to verify Claude API call succeeds
- [ ] Trigger retry-uploads workflow manually to verify fault isolation works

https://claude.ai/code/session_012bMjaNN3YfLo8RgNLB53vc