### PR TITLE
Cut GitHub Actions minute burn (pip cache + podcast M/W/F)

### DIFF
--- a/.github/workflows/_workflow_verify.yml
+++ b/.github/workflows/_workflow_verify.yml
@@ -21,6 +21,8 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
+          cache: 'pip'
+          cache-dependency-path: pipeline/requirements.txt
 
       - name: Install runtime deps
         run: |

--- a/.github/workflows/daily-content.yml
+++ b/.github/workflows/daily-content.yml
@@ -56,6 +56,8 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: '3.12'
+          cache: 'pip'
+          cache-dependency-path: pipeline/requirements.txt
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/generate-missing-videos.yml
+++ b/.github/workflows/generate-missing-videos.yml
@@ -18,6 +18,8 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: '3.12'
+          cache: 'pip'
+          cache-dependency-path: pipeline/requirements.txt
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/generate-podcast.yml
+++ b/.github/workflows/generate-podcast.yml
@@ -3,7 +3,7 @@ name: Generate Podcast Episode
 on:
   schedule:
     # 5:30 UTC = 11:00 IST daily — matches existing daily cadence
-    - cron: "30 5 * * *"
+    - cron: "30 5 * * 1,3,5"
   workflow_dispatch:
     inputs:
       slug:
@@ -29,6 +29,8 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: "3.12"
+          cache: 'pip'
+          cache-dependency-path: pipeline/requirements.txt
 
       - name: Install ffmpeg
         run: |

--- a/.github/workflows/generate-strip.yml
+++ b/.github/workflows/generate-strip.yml
@@ -39,6 +39,8 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: '3.12'
+          cache: 'pip'
+          cache-dependency-path: pipeline/requirements.txt
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/retry-uploads.yml
+++ b/.github/workflows/retry-uploads.yml
@@ -25,6 +25,8 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: '3.12'
+          cache: 'pip'
+          cache-dependency-path: pipeline/requirements.txt
 
       - name: Install dependencies
         run: pip install -r pipeline/requirements.txt

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,6 +13,8 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: '3.12'
+          cache: 'pip'
+          cache-dependency-path: pipeline/requirements.txt
       - name: Install dependencies
         run: |
           pip install -r pipeline/requirements.txt

--- a/.github/workflows/weekly-traffic-digest.yml
+++ b/.github/workflows/weekly-traffic-digest.yml
@@ -18,6 +18,8 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: '3.12'
+          cache: 'pip'
+          cache-dependency-path: pipeline/requirements.txt
 
       - name: Install dependencies
         run: pip install -r pipeline/requirements.txt

--- a/.github/workflows/welcome-new-subscriber.yml
+++ b/.github/workflows/welcome-new-subscriber.yml
@@ -33,6 +33,8 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: '3.12'
+          cache: 'pip'
+          cache-dependency-path: pipeline/requirements.txt
 
       - name: Install dependencies
         run: pip install -r pipeline/requirements.txt


### PR DESCRIPTION
zombielabsv2 hit 100% of its 2000 Actions min/month; lotus-lane was the culprit (Rahul forwarded the GitHub alert: "fix this decisively").

**Root cause:** every scheduled workflow ran a full `setup-python` + `pip install` from scratch, and the podcast ran daily (heaviest job: ffmpeg install + GCS auth + TTS).

**Fix:**
- pip caching on all 9 dep-installing workflows (`cache: 'pip'`, dependency path `pipeline/requirements.txt`)
- `generate-podcast.yml` daily → Mon/Wed/Fri, removing ~4 of the heaviest runs/week

All 10 workflow YAMLs validated. Config-only, no pipeline logic touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)